### PR TITLE
指定のUserIDの予定シフト取得に失敗した場合に, 予定シフトに存在しない旨を専用に表示

### DIFF
--- a/ShiftManager.Communication/InternalApi.ApiResult.cs
+++ b/ShiftManager.Communication/InternalApi.ApiResult.cs
@@ -87,6 +87,9 @@
     BreakTimeLen_Zero_Or_Less,
 
     /// <summary>氏名が一致しない</summary>
-    FullName_Not_Match
+    FullName_Not_Match,
+
+    /// <summary>予定シフトに指定のユーザIDが存在しない</summary>
+    UserID_Not_Found_In_Scheduled_Shift,
   }
 }

--- a/ShiftManager.Communication/InternalApi.ScheduledShift.cs
+++ b/ShiftManager.Communication/InternalApi.ScheduledShift.cs
@@ -27,7 +27,7 @@ namespace ShiftManager.Communication
         return new(false, ApiResultCodes.Target_Date_Not_Found, null);
 
       if (!scheduledShift.ShiftDictionary.TryGetValue(new(userID), out ISingleShiftData? singleShiftData) || singleShiftData is null)
-        return new(false, ApiResultCodes.UserID_Not_Found, null);
+        return new(false, ApiResultCodes.UserID_Not_Found_In_Scheduled_Shift, null);
       else
       {
         ApiResultCodes resultCode = scheduledShift.SchedulingState switch


### PR DESCRIPTION
Resolves #59 